### PR TITLE
Set refresh token cookie samesite to None

### DIFF
--- a/backend/accounts/api/views.py
+++ b/backend/accounts/api/views.py
@@ -90,7 +90,7 @@ class CookieTokenRefreshView(TokenRefreshView):
                 value=refresh_token,
                 httponly=True,
                 secure=settings.DEBUG is False,
-                samesite="lax",
+                samesite="None",
                 max_age=settings.SIMPLE_JWT["REFRESH_TOKEN_LIFETIME"].total_seconds()
             )
 
@@ -149,7 +149,7 @@ class LoginView(GenericAPIView):
             value=tokens["refresh"],
             httponly=True,
             secure=settings.DEBUG is False,
-            samesite='lax',
+            samesite='None',
             max_age=settings.SIMPLE_JWT["REFRESH_TOKEN_LIFETIME"].total_seconds()
         )
 


### PR DESCRIPTION
SameSite Policy: SameSite cookie attribute is set to Lax, which is more restrictive when it comes to cross-origin requests. For cookies to be sent in cross-origin requests (like frontend-to-backend setup),  need to change SameSite to None and ensure that the cookie is marked as Secure.